### PR TITLE
Detalles sobre /Properties/launchSettings.json

### DIFF
--- a/DemosMVC/Properties/launchSettings.json
+++ b/DemosMVC/Properties/launchSettings.json
@@ -23,6 +23,17 @@
       },
       "dotnetRunMessages": "true",
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "Watch": {
+      "commandName": "Executable",
+      "executablePath": "dotnet.exe",
+      "workingDirectory": "$(ProjectDir)",
+      "commandLineArgs": "watch run",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }


### PR DESCRIPTION
Hola Javier,

Echándole un vistazo y probando el funcionamiento del _launchSettings.json_ he visto que puede servir para dos cosas que hemos visto esta mañana en el curso:

- Añadir un perfil equivalente al _"dotnet watch"_ integrado en el menú, no desde la ventana de terminal.
- Establecer variables de entorno, por ejemplo para especificar _"Development, Staging o Production"_ y aún así poder depurar. Pues el valor que se establece aquí prevalece sobre el que se pone en la configuración "Debug".

Te lo comparto por si te parece interesante incorporarlo al proyecto del curso y/o darlo a conocer al resto.

PD. Es el primer _Pull Request_ que hago en GitHub y espero que te llegue, en cualquier caso, siéntete libre de rechazarlo.

Un saludo,
Jorge.